### PR TITLE
DEV-1931 Fix transport collection from TestTransport

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,5 +58,10 @@
             "@code-style",
             "@phpunit"
         ]
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }

--- a/src/Context/MessengerContext.php
+++ b/src/Context/MessengerContext.php
@@ -210,7 +210,7 @@ class MessengerContext implements Context
         }
 
         if (\class_exists(TestTransport::class) && $transport instanceof TestTransport) {
-            return $transport->dispatched();
+            return $transport->queue();
         }
 
         throw new Exception('Unknown transport ' . $transportName);


### PR DESCRIPTION
"dispatched" contains all events that ever were part of the queue, which is not what we are interested in, Our real interest is the current state of the queue, which is contained in the "queue" collection of TestTransport.